### PR TITLE
fix(i18n): claves faltantes y textos hardcoded en pantalla inicio

### DIFF
--- a/src/components/patients/PatientForm.tsx
+++ b/src/components/patients/PatientForm.tsx
@@ -153,7 +153,7 @@ const PatientForm: React.FC<PatientFormProps> = ({
               onChange={(e) =>
                 setFormData({ ...formData, patientId: e.target.value })
               }
-              placeholder="P-001"
+              placeholder={t('patients.placeholders.id')}
               required
               disabled={!!patient}
             />
@@ -165,7 +165,7 @@ const PatientForm: React.FC<PatientFormProps> = ({
               id="name"
               value={formData.name}
               onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              placeholder="Juan Pérez"
+              placeholder={t('patients.placeholders.name')}
               required
             />
           </div>

--- a/src/components/patients/PatientList.tsx
+++ b/src/components/patients/PatientList.tsx
@@ -85,11 +85,12 @@ const PatientList: React.FC = () => {
 
   const handleArchivePatient = async (patient: Patient) => {
     const isArchiving = (patient.status || 'active') === 'active';
-    const action = isArchiving ? 'archivar' : 'desarchivar';
 
     const confirmed = await confirm({
       title: isArchiving ? t('confirmations.archivePatientTitle') : t('confirmations.unarchivePatientTitle'),
-      description: t('confirmations.archivePatient', { action }),
+      description: isArchiving
+        ? t('confirmations.archivePatient')
+        : t('confirmations.unarchivePatient'),
       confirmText: t('common.confirm'),
       cancelText: t('common.cancel'),
       variant: 'warning',
@@ -101,8 +102,8 @@ const PatientList: React.FC = () => {
       await db.patients.update(patient.id!, { status: isArchiving ? 'archived' : 'active' });
       toast.success(isArchiving ? t('success.archivePatient') : t('success.unarchivePatient'));
     } catch (error) {
-      console.error(`Error ${action}ing patient:`, error);
-      toast.error(t('errors.archivePatient', { action }));
+      console.error('Error archiving/unarchiving patient:', error);
+      toast.error(isArchiving ? t('errors.archivePatient') : t('errors.unarchivePatient'));
     }
   };
   

--- a/src/components/tokens/TokenInfoModal.tsx
+++ b/src/components/tokens/TokenInfoModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Copy, Radio, CheckCircle, Info } from 'lucide-react';
 import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { getInstallationToken } from '@/lib/utils/installation';
@@ -12,15 +13,22 @@ interface TokenInfoModalProps {
 }
 
 export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
+  const { t } = useTranslation();
   const [isActivating, setIsActivating] = useState(false);
   const [beaconActive, setBeaconActive] = useState(false);
   const [timeRemaining, setTimeRemaining] = useState(0);
 
   const installationToken = getInstallationToken();
 
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
   const handleCopyToken = () => {
     navigator.clipboard.writeText(installationToken);
-    toast.success('Token copiado al portapapeles');
+    toast.success(t('tokens.modal.copied'));
   };
 
   const handleActivateBeacon = async () => {
@@ -30,9 +38,9 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
       const response = await activateBeacon(installationToken);
 
       if (response.already_active) {
-        toast.info(`Baliza ya está activa (${Math.floor(response.seconds_remaining / 60)}:${(response.seconds_remaining % 60).toString().padStart(2, '0')} restantes)`);
+        toast.info(t('tokens.beacon.alreadyActive', { time: formatTime(response.seconds_remaining) }));
       } else {
-        toast.success('¡Baliza activada! El administrador será notificado.');
+        toast.success(t('tokens.beacon.activated'));
         setBeaconActive(true);
         setTimeRemaining(response.seconds_remaining);
 
@@ -49,17 +57,11 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
         }, 1000);
       }
     } catch (error) {
-      toast.error('Error al activar baliza');
+      toast.error(t('tokens.beacon.error'));
       console.error(error);
     } finally {
       setIsActivating(false);
     }
-  };
-
-  const formatTime = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
   return (
@@ -68,7 +70,7 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Info className="w-5 h-5" />
-            Mi Token de Sesión
+            {t('tokens.modal.title')}
           </DialogTitle>
         </DialogHeader>
 
@@ -76,7 +78,7 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
           {/* Token Display */}
           <div className="space-y-2">
             <p className="text-sm text-smoke-600 dark:text-dark-textSecondary">
-              Este es tu identificador único de instalación:
+              {t('tokens.modal.description')}
             </p>
             <div className="bg-smoke-100 dark:bg-coal-900 rounded-lg p-4 border border-smoke-200 dark:border-coal-700">
               <code className="text-xs font-mono text-coal-800 dark:text-dark-text break-all block">
@@ -90,7 +92,7 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
               className="w-full gap-2"
             >
               <Copy className="w-4 h-4" />
-              Copiar Token
+              {t('tokens.modal.copyButton')}
             </Button>
           </div>
 
@@ -102,15 +104,15 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
                   <div className="flex items-center gap-2 mb-2">
                     <CheckCircle className="w-5 h-5 text-green-600 dark:text-green-400" />
                     <h3 className="font-semibold text-green-800 dark:text-green-300">
-                      Baliza Activa
+                      {t('tokens.beacon.active')}
                     </h3>
                   </div>
                   <p className="text-sm text-green-700 dark:text-green-400">
-                    El administrador ha sido notificado de tu solicitud de ayuda.
+                    {t('tokens.beacon.adminNotified')}
                   </p>
                   <div className="mt-3 flex items-center justify-between">
                     <span className="text-sm text-green-600 dark:text-green-400">
-                      Tiempo restante:
+                      {t('tokens.beacon.timeRemaining')}
                     </span>
                     <span className="font-mono text-lg font-bold text-green-700 dark:text-green-300">
                       {formatTime(timeRemaining)}
@@ -134,12 +136,12 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
                   size="lg"
                 >
                   <Radio className={`w-5 h-5 ${isActivating ? 'animate-pulse' : ''}`} />
-                  {isActivating ? 'Activando...' : '🚨 Encender Baliza'}
+                  {isActivating ? t('tokens.beacon.activating') : t('tokens.beacon.activate')}
                 </Button>
                 <div className="bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-lg p-3">
                   <p className="text-xs text-amber-800 dark:text-amber-300">
-                    <strong>ℹ️ ¿Qué es la baliza?</strong><br />
-                    La baliza alertará al administrador durante 5 minutos. Úsala cuando necesites ayuda urgente.
+                    <strong>{t('tokens.beacon.info.title')}</strong><br />
+                    {t('tokens.beacon.info.description')}
                   </p>
                 </div>
               </div>
@@ -153,7 +155,7 @@ export function TokenInfoModal({ open, onOpenChange }: TokenInfoModalProps) {
             onClick={() => onOpenChange(false)}
             className="w-full"
           >
-            Cerrar
+            {t('tokens.modal.close')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/hooks/useMessagePolling.ts
+++ b/src/hooks/useMessagePolling.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
 import { fetchPendingMessages, markMessageAsRead } from '@/lib/api/admin-service';
 import { getInstallationToken } from '@/lib/utils/installation';
 import { useConfirm } from '@/hooks/useConfirm';
@@ -27,6 +28,7 @@ export interface UseMessagePollingOptions {
 export function useMessagePolling(options: UseMessagePollingOptions = {}) {
   const { intervalMs = 120000, enabled = true } = options;
 
+  const { t } = useTranslation();
   const [isChecking, setIsChecking] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const { confirm, ConfirmDialogComponent } = useConfirm();
@@ -50,18 +52,18 @@ export function useMessagePolling(options: UseMessagePollingOptions = {}) {
     } else {
       // Show modal dialog
       const variantConfig = {
-        info: { title: 'Información', variant: 'default' as const },
-        success: { title: 'Mensaje', variant: 'default' as const },
-        warning: { title: 'Advertencia', variant: 'warning' as const },
-        error: { title: 'Atención', variant: 'destructive' as const },
+        info: { titleKey: 'messages.info', variant: 'default' as const },
+        success: { titleKey: 'messages.message', variant: 'default' as const },
+        warning: { titleKey: 'messages.warning', variant: 'warning' as const },
+        error: { titleKey: 'messages.attention', variant: 'destructive' as const },
       };
 
       const config = variantConfig[message.variant] || variantConfig.info;
 
       await confirm({
-        title: config.title,
+        title: t(config.titleKey),
         description: message.text,
-        confirmText: 'Aceptar',
+        confirmText: t('messages.accept'),
         variant: config.variant,
       });
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -47,6 +47,26 @@
     "loadingPDF": "Loading PDF...",
     "failedToLoadPDF": "Failed to load PDF document"
   },
+  "common": {
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "error": {
+      "dbBlocked": "Please close other tabs of this application to allow the database update."
+    }
+  },
+  "messages": {
+    "info": "Information",
+    "message": "Message",
+    "warning": "Warning",
+    "attention": "Attention",
+    "accept": "OK"
+  },
+  "success": {
+    "deletePatient": "Patient deleted successfully",
+    "archivePatient": "Patient archived",
+    "unarchivePatient": "Patient unarchived"
+  },
   "errors": {
     "unknown": "Unknown error",
     "exportStudy": "Error exporting study.",
@@ -57,7 +77,8 @@
     "duplicateStudy": "Error duplicating study.",
     "import": "Import Error",
     "deletePatient": "Error deleting patient.",
-    "archivePatient": "Error {{action}} patient.",
+    "archivePatient": "Error archiving patient.",
+    "unarchivePatient": "Error unarchiving patient.",
     "drClassification": {
       "noClassification": "Could not generate classification",
       "noClassifications": "Could not generate classifications"
@@ -68,7 +89,11 @@
     "deleteStudy": "Are you sure you want to delete this study and all its data? This action is irreversible.",
     "duplicateStudy": "Are you sure you want to duplicate this study? This action will create a copy with the same elements but unlocked.",
     "deletePatient": "Are you sure you want to delete this patient and all their data? This action is irreversible.",
-    "archivePatient": "Are you sure you want to {{action}} this patient?"
+    "deletePatientTitle": "Delete Patient",
+    "archivePatient": "Are you sure you want to archive this patient?",
+    "unarchivePatient": "Are you sure you want to unarchive this patient?",
+    "archivePatientTitle": "Archive Patient",
+    "unarchivePatientTitle": "Unarchive Patient"
   },
   "patients": {
     "title": "Patients",
@@ -90,6 +115,45 @@
     "description": "Manage patients and their analysis studies",
     "notFound": "No patients found",
     "empty": "No patients registered. Create one to start.",
+    "sessions": "studies",
+    "status": {
+      "no_report": "No Report",
+      "preliminary": "Draft"
+    },
+    "medicalLabels": {
+      "diabetes": "Diabetes",
+      "hta": "HTN",
+      "dlp": "DLP"
+    },
+    "filter": {
+      "allStatus": "All statuses",
+      "pendingReport": "Pending Report"
+    },
+    "placeholders": {
+      "id": "P-001",
+      "name": "John Doe"
+    },
+    "form": {
+      "editDescription": "Edit patient information",
+      "createDescription": "Fill in the data to create a new patient",
+      "medicalHistory": "Medical History",
+      "diabetes": "Diabetes",
+      "diabetesType": "Diabetes Type",
+      "selectType": "Select type",
+      "types": {
+        "type1": "Type 1",
+        "type2": "Type 2",
+        "gestational": "Gestational",
+        "other": "Other"
+      },
+      "diabetesDuration": "Years with Diabetes",
+      "diabetesDurationPlaceholder": "Years since diagnosis",
+      "hta": "Arterial Hypertension (HTN)",
+      "dlp": "Dyslipidemia (DLP)",
+      "medicationsPlaceholder": "List of medications separated by commas",
+      "otherConditions": "Other History",
+      "otherConditionsPlaceholder": "Other relevant medical history..."
+    },
     "fields": {
       "name": "Name",
       "email": "Email",
@@ -1299,6 +1363,58 @@
       "criteria": "Criteria",
       "recommendations": "Recommendations",
       "warnings": "Warnings"
+    }
+  },
+  "loading": {
+    "title": "Preparing DIRD",
+    "subtitle": "Loading required resources",
+    "info": "Loading the components required for the application to run.",
+    "steps": {
+      "init": "Initializing",
+      "tokens": "Checking tokens",
+      "model": "Loading AI model",
+      "opencv": "Initializing OpenCV",
+      "done": "Completed"
+    }
+  },
+  "demo": {
+    "loading": {
+      "title": "Preparing DIRD",
+      "subtitle": "Loading demo patient and resources",
+      "firstTimeInfo": "First load may take a few seconds while AI models and demo images are prepared.",
+      "imagesProgress": "Processing image {{current}} of {{total}}",
+      "steps": {
+        "init": "Initializing",
+        "patient": "Creating demo patient",
+        "model": "Loading AI model",
+        "modelLoaded": "AI model loaded",
+        "images": "Processing images",
+        "report": "Generating report",
+        "done": "Completed"
+      }
+    }
+  },
+  "tokens": {
+    "modal": {
+      "title": "My Session Token",
+      "description": "This is your unique installation identifier:",
+      "copyButton": "Copy Token",
+      "copied": "Token copied to clipboard",
+      "close": "Close"
+    },
+    "beacon": {
+      "active": "Beacon Active",
+      "adminNotified": "The administrator has been notified of your help request.",
+      "timeRemaining": "Time remaining:",
+      "activate": "🚨 Trigger Beacon",
+      "activating": "Activating...",
+      "activated": "Beacon activated! The administrator will be notified.",
+      "alreadyActive": "Beacon already active ({{time}} remaining)",
+      "error": "Error activating beacon",
+      "info": {
+        "title": "ℹ️ What is the beacon?",
+        "description": "The beacon will alert the administrator for 5 minutes. Use it when you need urgent help."
+      }
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -50,7 +50,22 @@
   "common": {
     "confirm": "Confirmar",
     "cancel": "Cancelar",
-    "delete": "Eliminar"
+    "delete": "Eliminar",
+    "error": {
+      "dbBlocked": "Por favor cierra otras pestañas de esta aplicación para permitir la actualización de la base de datos."
+    }
+  },
+  "messages": {
+    "info": "Información",
+    "message": "Mensaje",
+    "warning": "Advertencia",
+    "attention": "Atención",
+    "accept": "Aceptar"
+  },
+  "success": {
+    "deletePatient": "Paciente eliminado correctamente",
+    "archivePatient": "Paciente archivado",
+    "unarchivePatient": "Paciente desarchivado"
   },
   "errors": {
     "savePatient": "Error al guardar el paciente",
@@ -64,7 +79,8 @@
     "duplicateSession": "Error al duplicar el estudio.",
     "import": "Error de Importación",
     "deletePatient": "Error al eliminar el paciente.",
-    "archivePatient": "Error al {{action}} el paciente.",
+    "archivePatient": "Error al archivar el paciente.",
+    "unarchivePatient": "Error al desarchivar el paciente.",
     "processingImages": "Error procesando imágenes: {{error}}",
     "drClassification": {
       "noClassification": "No se pudo generar la clasificación",
@@ -76,7 +92,11 @@
     "deleteSession": "¿Estás seguro de que quieres eliminar este estudio y todos sus datos? Esta acción es irreversible.",
     "duplicateSession": "¿Estás seguro de que deseas duplicar este estudio? Esta acción creará una copia con los mismos elementos pero desbloqueada.",
     "deletePatient": "¿Estás seguro de que quieres eliminar este paciente y todos sus datos? Esta acción es irreversible.",
-    "archivePatient": "¿Estás seguro de que quieres {{action}} este paciente?",
+    "deletePatientTitle": "Eliminar Paciente",
+    "archivePatient": "¿Estás seguro de que quieres archivar este paciente?",
+    "unarchivePatient": "¿Estás seguro de que quieres desarchivar este paciente?",
+    "archivePatientTitle": "Archivar Paciente",
+    "unarchivePatientTitle": "Desarchivar Paciente",
     "deleteReportTitle": "Eliminar Informe",
     "finalizeReportTitle": "Finalizar Informe"
   },
@@ -129,6 +149,10 @@
     "filter": {
       "allStatus": "Todos los estados",
       "pendingReport": "Pendientes de Informe"
+    },
+    "placeholders": {
+      "id": "P-001",
+      "name": "Juan Pérez"
     },
     "form": {
       "editDescription": "Edita la información del paciente",
@@ -1455,6 +1479,46 @@
       "model": "Cargando modelo de IA",
       "opencv": "Inicializando OpenCV",
       "done": "Completado"
+    }
+  },
+  "demo": {
+    "loading": {
+      "title": "Preparando DIRD",
+      "subtitle": "Cargando paciente demo y recursos",
+      "firstTimeInfo": "La primera carga puede tardar unos segundos mientras se preparan los modelos de IA y las imágenes demo.",
+      "imagesProgress": "Procesando imagen {{current}} de {{total}}",
+      "steps": {
+        "init": "Inicializando",
+        "patient": "Creando paciente demo",
+        "model": "Cargando modelo de IA",
+        "modelLoaded": "Modelo de IA cargado",
+        "images": "Procesando imágenes",
+        "report": "Generando informe",
+        "done": "Completado"
+      }
+    }
+  },
+  "tokens": {
+    "modal": {
+      "title": "Mi Token de Sesión",
+      "description": "Este es tu identificador único de instalación:",
+      "copyButton": "Copiar Token",
+      "copied": "Token copiado al portapapeles",
+      "close": "Cerrar"
+    },
+    "beacon": {
+      "active": "Baliza Activa",
+      "adminNotified": "El administrador ha sido notificado de tu solicitud de ayuda.",
+      "timeRemaining": "Tiempo restante:",
+      "activate": "🚨 Encender Baliza",
+      "activating": "Activando...",
+      "activated": "¡Baliza activada! El administrador será notificado.",
+      "alreadyActive": "Baliza ya está activa ({{time}} restantes)",
+      "error": "Error al activar baliza",
+      "info": {
+        "title": "ℹ️ ¿Qué es la baliza?",
+        "description": "La baliza alertará al administrador durante 5 minutos. Úsala cuando necesites ayuda urgente."
+      }
     }
   },
   "clinical": {


### PR DESCRIPTION
## Summary
- Elimina textos hardcoded en español en `TokenInfoModal`, `useMessagePolling`, `PatientList` y `PatientForm`.
- Corrige fuga i18n en `PatientList` donde se interpolaba `'archivar'`/`'desarchivar'` dentro de `t()`. Ahora usa claves separadas archive/unarchive.
- Agrega claves faltantes en `es.json` y `en.json`: `success.*`, `messages.*`, `tokens.modal.*`, `tokens.beacon.*`, `demo.loading.*`, `patients.placeholders.*`, titles de confirmación.
- Resuelve asimetría crítica en `en.json`: agrega `common`, `patients.status`, `patients.medicalLabels`, `patients.filter`, `patients.form.*`, `loading.*`.

## Archivos modificados
- `src/components/patients/PatientList.tsx`
- `src/components/patients/PatientForm.tsx`
- `src/components/tokens/TokenInfoModal.tsx`
- `src/hooks/useMessagePolling.ts`
- `src/i18n/locales/es.json`
- `src/i18n/locales/en.json`

## Test plan
- [ ] Cargar app → pantalla demo loading muestra textos en lugar de claves literales
- [ ] Modal token (click counter header): título, descripción, botones y beacon traducidos
- [ ] Archivar/desarchivar paciente: confirmaciones y toasts correctos ES y EN
- [ ] Crear paciente: placeholders traducidos
- [ ] Cambiar idioma Settings → ES ↔ EN sin claves crudas visibles
- [ ] `npx tsc --noEmit` limpio